### PR TITLE
accessibility/override-default-link-style

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,8 @@
-import "./colors.css";
-import "./steps.css";
 import "@mozilla-protocol/core/protocol/css/protocol.css";
 import "@mozilla-protocol/core/protocol/css/protocol-extra.css";
+import "./cdp.css";
+import "./colors.css";
+import "./steps.css";
 import ReactGA from "react-ga";
 
 //Import Components 

--- a/src/cdp.css
+++ b/src/cdp.css
@@ -1,0 +1,9 @@
+.cdp-link {
+  color: black;
+  text-decoration: underline;
+}
+
+.cdp-link:hover {
+  color: black;
+  text-decoration: none;
+}

--- a/src/components/layout/Contributing.js
+++ b/src/components/layout/Contributing.js
@@ -17,18 +17,18 @@ export default function Contributing() {
               <p>
                 If you would like to contribute in any of these areas, please
                 reach out on{" "}
-                <a href="https://www.democracylab.org/index/?section=AboutProject&id=145">
+                <a class="cdp-link" href="https://www.democracylab.org/index/?section=AboutProject&id=145">
                   DemocracyLab
                 </a>{" "}
                 or simply start tackling issues in one of our{" "}
-                <a href="https://github.com/CouncilDataProject">
+                <a class="cdp-link" href="https://github.com/CouncilDataProject">
                   GitHub repositories
                 </a>
                 .
               </p>
               <dl class="mzp-u-list-styled">
                 <dt>
-                  <a href="https://github.com/CouncilDataProject/cdp-backend">
+                  <a class="cdp-link" href="https://github.com/CouncilDataProject/cdp-backend">
                     cdp-backend
                   </a>
                 </dt>
@@ -39,7 +39,7 @@ export default function Contributing() {
                   Python.
                 </dd>
                 <dt>
-                  <a href="https://github.com/CouncilDataProject/cdp-frontend">
+                  <a class="cdp-link" href="https://github.com/CouncilDataProject/cdp-frontend">
                     cdp-frontend
                   </a>
                 </dt>
@@ -50,13 +50,13 @@ export default function Contributing() {
                   React.
                 </dd>
                 <dt>
-                  <a href="https://github.com/CouncilDataProject/cookiecutter-cdp-deployment">
+                  <a class="cdp-link" href="https://github.com/CouncilDataProject/cookiecutter-cdp-deployment">
                     cookiecutter-cdp-deployment
                   </a>
                 </dt>
                 <dd>
                   A template to be used by the Python{" "}
-                  <a href="https://github.com/cookiecutter/cookiecutter">
+                  <a class="cdp-link" href="https://github.com/cookiecutter/cookiecutter">
                     cookiecutter
                   </a>{" "}
                   package to create an entirely new deployment repository. This
@@ -64,13 +64,13 @@ export default function Contributing() {
                   imported and used. If you would like to create a new
                   deployment under the <em>councildataproject</em> domain please
                   log a{" "}
-                  <a href="https://github.com/CouncilDataProject/councildataproject.github.io/issues">
+                  <a class="cdp-link" href="https://github.com/CouncilDataProject/councildataproject.github.io/issues">
                     GitHub issue
                   </a>
                   .
                 </dd>
                 <dt>
-                  <a href="https://github.com/CouncilDataProject/councildataproject.github.io">
+                  <a class="cdp-link" href="https://github.com/CouncilDataProject/councildataproject.github.io">
                     councildataproject.github.io
                   </a>
                 </dt>
@@ -82,21 +82,21 @@ export default function Contributing() {
               <h3>Contributors</h3>
               <p>
                 Council Data Project was created by{" "}
-                <a href="https://jacksonmaxfield.github.io/">
+                <a class="cdp-link" href="https://jacksonmaxfield.github.io/">
                   Jackson Maxfield Brown
                 </a>{" "}
-                and <a href="http://nicweber.info/">Nic Weber</a>.
+                and <a class="cdp-link" href="http://nicweber.info/">Nic Weber</a>.
               </p>
               <p>
                 There have been major contributions from:{" "}
-                <a href="https://github.com/tohuynh">To Huynh</a> (Full Stack
-                Development), <a href="https://www.isaacna.com/">Isaac Na</a>{" "}
+                <a class="cdp-link" href="https://github.com/tohuynh">To Huynh</a> (Full Stack
+                Development), <a class="cdp-link" href="https://www.isaacna.com/">Isaac Na</a>{" "}
                 (Backend Development),{" "}
-                <a href="https://www.katlynmfgreene.com/">Katlyn M.F. Greene</a>{" "}
+                <a class="cdp-link" href="https://www.katlynmfgreene.com/">Katlyn M.F. Greene</a>{" "}
                 (UX Research),{" "}
-                <a href="https://www.emilygilles.design/">Emily Gilles</a> (UX
+                <a class="cdp-link" href="https://www.emilygilles.design/">Emily Gilles</a> (UX
                 Design), and{" "}
-                <a href="https://www.linkedin.com/in/madeleine-farrer-14a1a3118/">
+                <a class="cdp-link" href="https://www.linkedin.com/in/madeleine-farrer-14a1a3118/">
                   Madeleine Farrer
                 </a>{" "}
                 (Logo Design).
@@ -104,14 +104,14 @@ export default function Contributing() {
               <p>
                 Much of our second prototype can be attributed to the voluteers
                 from{" "}
-                <a href="https://medium.com/democracylab-org/textio-engages-employees-to-accelerate-civic-innovation-5984609a95ce">
+                <a class="cdp-link" href="https://medium.com/democracylab-org/textio-engages-employees-to-accelerate-civic-innovation-5984609a95ce">
                   Textio
                 </a>
                 .
               </p>
               <p>
                 Many volunteers and contributors have found the project through{" "}
-                <a href="https://www.democracylab.org/index/?section=Home">
+                <a class="cdp-link" href="https://www.democracylab.org/index/?section=Home">
                   DemocracyLab
                 </a>
                 .


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

**Summary of Changes**
Created a new `cdp.css` and added a `cdp-link` class which can be used to override default link styles inside components for improved accessibility (i.e. creating a better contrast between the link color and background color).

I subsequently updated all the links inside the Contributing component to use this new CSS class.
