### PR TITLE
Increase resolution of CDP logo in Nav bar

### DIFF
--- a/src/components/layout/Navigation.js
+++ b/src/components/layout/Navigation.js
@@ -46,10 +46,12 @@ export default function Navigation({ links }) {
         <div className="mzp-c-navigation-l-content">
           <div className="mzp-c-navigation-container">
             <div
-              className="cdp-icon-black-bg-transparent-size-64"
+              className="cdp-icon-black-bg-transparent-size-128"
               style={{
                 float: "left",
                 marginTop: "12px",
+                maxHeight: "64px",
+                maxWidth: "64px"
               }}
             >
               <a href="#top">CDP logo</a>


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Description of Changes

- Increasing the resolution of the CDP logo by using the 128 pixel image variant
- I did 128 since it seems sharp enough, but can bump to 256 if desired

Before:
<img width="384" alt="before_logo" src="https://user-images.githubusercontent.com/20964645/136141502-ec182fd6-e7fb-4e7b-81e2-2c0961faf151.png">

After:
<img width="389" alt="after_logo" src="https://user-images.githubusercontent.com/20964645/136141513-e2cdb967-ccd8-417d-be98-8951489537a8.png">


