### PR TITLE
Bump CDP logo res to 256px

### DIFF
--- a/src/components/layout/Navigation.js
+++ b/src/components/layout/Navigation.js
@@ -46,7 +46,7 @@ export default function Navigation({ links }) {
         <div className="mzp-c-navigation-l-content">
           <div className="mzp-c-navigation-container">
             <div
-              className="cdp-icon-black-bg-transparent-size-128"
+              className="cdp-icon-black-bg-transparent-size-256"
               style={{
                 float: "left",
                 marginTop: "12px",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->


### Description of Changes
- Meant to push this before the last PR got merged. Bumping to 256 because 128 still gets fuzzy relative to rest of the page when you zoom in on the logo
